### PR TITLE
index.html: Fix typo in AMD Athlon

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,9 +343,9 @@
                 <option value="intel-atom">Intel Atom</option>
                 <option value="intel-ix">Intel Celeron/i3/i5/i7/i9</option>
                 <option value="intel-core2duo">Intel Core2Duo &amp; older Celeron</option>
-                <option value="amd-anthlon">AMD Anthlon</option>
+                <option value="amd-athlon">AMD Athlon</option>
                 <option value="amd-ryzen">AMD Ryzen</option>
-                <option value="qcom">qualcomm snapdragon</option>
+                <option value="qcom">Qualcomm Snapdragon</option>
                 <option value="surface">Microsoft Surface (Atom/Celeron/i3/i5/i7/i9)</option>
               </select>
               <div class="conditional" data-cond-option="cputype" data-cond-value="intel-atom">
@@ -395,7 +395,7 @@
                   </div>
                 </div>
               </div>
-              <div class="conditional" data-cond-option="cputype" data-cond-value="amd-anthlon">
+              <div class="conditional" data-cond-option="cputype" data-cond-value="amd-athlon">
                 <p>Here is the download:</p>
                 <div class="tabbutton-6 " style="margin-bottom: 1.5rem !important; ">
                   <input id="tabbutton-6-one" type="checkbox" name="tabbutton-s" style=" width: 0px; margin-left: -10px;">
@@ -455,9 +455,9 @@
                 <option value="intel-atom">Intel Atom</option>
                 <option value="intel-ix">Intel Celeron/i3/i5/i7/i9</option>
                 <option value="intel-core2duo">Intel Core2Duo &amp; older Celeron</option>
-                <option value="amd-anthlon">AMD Anthlon</option>
+                <option value="amd-athlon">AMD Athlon</option>
                 <option value="amd-ryzen">AMD Ryzen</option>
-                <option value="qcom">qualcomm snapdragon</option>
+                <option value="qcom">Qualcomm Snapdragon</option>
                 <option value="surface">Microsoft Surface (Atom/Celeron/i3/i5/i7/i9)</option>
               </select>
               <div class="conditional" data-cond-option="cputype2" data-cond-value="intel-atom">
@@ -507,7 +507,7 @@
                   </div>
                 </div>
               </div>
-              <div class="conditional" data-cond-option="cputype2" data-cond-value="amd-anthlon">
+              <div class="conditional" data-cond-option="cputype2" data-cond-value="amd-athlon">
                 <p>Here is the download we recommend:</p>
                 <div class="tabbutton-12 " style="margin-bottom: 1.5rem !important; ">
                   <input id="tabbutton-12-one" type="checkbox" name="tabbutton-s" style=" width: 0px; margin-left: -10px;">


### PR DESCRIPTION
For some reason I can't take my eyes off when downloading bliss builds, hence I fixed it and hopefully it doesn't break since I also changed `amd-anthlon` value to `amd-athlon`. 

Also fixed qualcomm snapdragon to Qualcomm Snapdragon. being a lil bit nitpicky, I would suggest to reorder the list as such based on cpu vendor, but it's up to you to consider it. for now I'm assuming Surface= Intel since i don't see any specific build for Ryzen-based Surface device. 

```
<option value="Pick one!">Pick one!</option>
<option value="intel-core2duo">Intel Core2Duo &amp; older Celeron</option>
<option value="intel-atom">Intel Atom</option>
<option value="intel-ix">Intel Celeron/i3/i5/i7/i9</option>
<option value="surface">Microsoft Surface (Atom/Celeron/i3/i5/i7/i9)</option>
<option value="amd-athlon">AMD Athlon</option>
<option value="amd-ryzen">AMD Ryzen</option>
<option value="qcom">Qualcomm Snapdragon</option>
```