### PR TITLE
Avoids reload of index.html on header links

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,25 +51,25 @@
 
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                         <li class="nav-item mx-2">
-                            <a class="nav-link" href="index.html#features">Features</a>
+                            <a class="nav-link" href="#features">Features</a>
                         </li>
                         <li class="nav-item mx-2">
-                            <a class="nav-link" href="index.html#about">About</a>
+                            <a class="nav-link" href="#about">About</a>
                         </li>
                         <li class="nav-item mx-2">
-                            <a class="nav-link" href="index.html#team">Team</a>
+                            <a class="nav-link" href="#team">Team</a>
                         </li>
                         <li class="nav-item mx-2">
                             <a class="nav-link" href="https://blisslabs.org" target="_blank">Non Profit</a>
                         </li>
                         <li class="nav-item mx-2">
-                            <a class="nav-link" href="index.html#documentation">Docs</a>
+                            <a class="nav-link" href="#documentation">Docs</a>
                         </li>
                         <li class="nav-item mx-2">
                             <a class="nav-link" target="_blank" href="https://blog.blissos.org">Blog</a>
                         </li>
                     </ul>
-                    <a class="btn navbar-btn mx-2 btn-secondary shadow" href="index.html#download">Download</a>
+                    <a class="btn navbar-btn mx-2 btn-secondary shadow" href="#download">Download</a>
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
Just a small PR. I removed the usage of `index.html` in navigation links, so it won't load the `index.html` when clicking for the first time. Just follows the anchor.