### PR TITLE
Fix link to GitHub repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
                     <div class="col-sm col-md-3 d-flex p-4">
                         <a href="https://www.facebook.com/BlissFamilyOfROMs/" target="_blank"><i class="fa fa-facebook-official mr-2 text-light fa-2x"></i></a>
                         <a href="https://instagram.com/blissos_org" target="_blank"><i class="fa fa-instagram mx-2 text-light fa-2x"></i></a>
-                        <a href=" github.com/blissroms-x86" target="_blank"><i class="fa fa-github mx-2 text-light fa-2x"></i></a>
+                        <a href="https://github.com/blissroms-x86" target="_blank"><i class="fa fa-github mx-2 text-light fa-2x"></i></a>
                         <a href="https://www.reddit.com/r/BlissOS" target="_blank"><i class="fa fa-reddit mx-2 text-light fa-2x"></i></a>
                         <a href="https://twitter.com/blissos_org" target="_blank"><i class="fa fa-twitter ml-2 text-light fa-2x"></i></a>
                         <a href="https://discord.com/invite/F9n5gbdNy2" target="_blank"><i class="fab fa-discord ml-2 text-light fa-2x"></i></a>


### PR DESCRIPTION
There was a space inside an `<a>` tag. :wink: 